### PR TITLE
feat: メッセージテンプレートを更新

### DIFF
--- a/components/ui/message-preview.test.tsx
+++ b/components/ui/message-preview.test.tsx
@@ -25,8 +25,9 @@ describe("MessagePreview", () => {
         name: "Slackメッセージ内容",
       });
       expect(messageContent).toHaveTextContent("■店名：ラーメン太郎");
+      expect(messageContent).toHaveTextContent("■場所：東京都渋谷区");
       expect(messageContent).toHaveTextContent(
-        "■場所：東京都渋谷区（https://example.com/ramen-taro）",
+        "■リンク：https://example.com/ramen-taro",
       );
       expect(messageContent).toHaveTextContent("■メニュー名：味噌ラーメン");
       expect(messageContent).toHaveTextContent("■金額：￥850");
@@ -64,7 +65,8 @@ describe("MessagePreview", () => {
         name: "Slackメッセージ内容",
       });
       expect(messageContent).toHaveTextContent("■店名：");
-      expect(messageContent).toHaveTextContent("■場所：（）");
+      expect(messageContent).toHaveTextContent("■場所：");
+      expect(messageContent).toHaveTextContent("■リンク：");
       expect(messageContent).toHaveTextContent("■金額：￥0");
     });
   });

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -38,7 +38,8 @@ describe("generateSlackMessage", () => {
     };
 
     const expected = `■店名：ラーメン太郎
-■場所：東京都渋谷区（https://example.com/ramen-taro）
+■場所：東京都渋谷区
+■リンク：https://example.com/ramen-taro
 ■メニュー名：味噌ラーメン
 ■金額：￥850
 ■味：★★★★☆
@@ -63,7 +64,8 @@ describe("generateSlackMessage", () => {
     };
 
     const expected = `■店名：らーめん次郎
-■場所：新宿区（https://example.com/jiro）
+■場所：新宿区
+■リンク：https://example.com/jiro
 ■メニュー名：豚骨ラーメン
 ■金額：￥1200
 ■味：★★★★★
@@ -88,7 +90,8 @@ describe("generateSlackMessage", () => {
     };
 
     const expected = `■店名：A
-■場所：B（https://c.com）
+■場所：B
+■リンク：https://c.com
 ■メニュー名：D
 ■金額：￥1
 ■味：★☆☆☆☆

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,7 +14,8 @@ export function formatStars(rating: number): string {
 
 export function generateSlackMessage(data: ReviewFormData): string {
   return `■店名：${data.storeName}
-■場所：${data.location}（${data.storeLink}）
+■場所：${data.location}
+■リンク：${data.storeLink}
 ■メニュー名：${data.menuName}
 ■金額：￥${data.price}
 ■味：${formatStars(data.tasteRating)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Slack message layout: location and link now appear on separate lines for improved readability.
  * In cases with missing data, labels render without empty parentheses; a dedicated link line is shown when available.

* **Tests**
  * Adjusted test expectations to match the new Slack message formatting, including separate lines for location and link and updated handling of empty fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->